### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # ChatGPT MCP Server
+[![smithery badge](https://smithery.ai/badge/@Toowiredd/chatgpt-mcp-server)](https://smithery.ai/server/@Toowiredd/chatgpt-mcp-server)
 
 A Model Context Protocol (MCP) server that provides Docker management capabilities through a custom GPT interface.
 
@@ -10,7 +11,15 @@ A Model Context Protocol (MCP) server that provides Docker management capabiliti
 - Containerized deployment
 
 ## Setup
+### Installing via Smithery
 
+To install ChatGPT MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@Toowiredd/chatgpt-mcp-server):
+
+```bash
+npx -y @smithery/cli install @Toowiredd/chatgpt-mcp-server --client claude
+```
+
+### Manual Installation
 1. Clone the repository
 ```bash
 git clone https://github.com/toowiredd/chatgpt-mcp-server.git

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,29 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - apiKey
+    properties:
+      apiKey:
+        type: string
+        description: The API authentication key for the server.
+      httpPort:
+        type: number
+        default: 3001
+        description: The port the server listens on.
+      rateLimitRequests:
+        type: number
+        default: 100
+        description: Maximum number of requests allowed per window.
+      rateLimitWindow:
+        type: number
+        default: 60000
+        description: Window size in milliseconds for rate limiting.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({ command: 'node', args: ['build/index.js'], env: { API_KEY: config.apiKey, HTTP_PORT: config.httpPort.toString(), RATE_LIMIT_REQUESTS: config.rateLimitRequests.toString(), RATE_LIMIT_WINDOW: config.rateLimitWindow.toString() } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@Toowiredd/chatgpt-mcp-server?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂